### PR TITLE
caching getMetadata result

### DIFF
--- a/src/CopyAdapter.php
+++ b/src/CopyAdapter.php
@@ -192,18 +192,19 @@ class CopyAdapter extends AbstractAdapter
     {
         static $cache = [];
 
-        if (isset($cache[$path])) {
-            return $cache[$path];
+        $location = $this->applyPathPrefix($path);
+
+        if (isset($cache[$location])) {
+            return $cache[$location];
         }
 
-        $location = $this->applyPathPrefix($path);
         $objects = $this->client->listPath($location);
 
         if ($objects === false || isset($objects[0]) === false || empty($objects[0])) {
-            return $cache[$path] = false;
+            return $cache[$location] = false;
         }
 
-        return $cache[$path] = $this->normalizeObject($objects[0], $path);
+        return $cache[$location] = $this->normalizeObject($objects[0], $path);
     }
 
     /**

--- a/src/CopyAdapter.php
+++ b/src/CopyAdapter.php
@@ -200,7 +200,7 @@ class CopyAdapter extends AbstractAdapter
         $objects = $this->client->listPath($location);
 
         if ($objects === false || isset($objects[0]) === false || empty($objects[0])) {
-            return false;
+            return $cache[$path] = false;
         }
 
         return $cache[$path] = $this->normalizeObject($objects[0], $path);

--- a/src/CopyAdapter.php
+++ b/src/CopyAdapter.php
@@ -190,6 +190,12 @@ class CopyAdapter extends AbstractAdapter
      */
     public function getMetadata($path)
     {
+        static $cache = [];
+
+        if (isset($cache[$path])) {
+            return $cache[$path];
+        }
+
         $location = $this->applyPathPrefix($path);
         $objects = $this->client->listPath($location);
 
@@ -197,7 +203,7 @@ class CopyAdapter extends AbstractAdapter
             return false;
         }
 
-        return $this->normalizeObject($objects[0], $path);
+        return $cache[$path] = $this->normalizeObject($objects[0], $path);
     }
 
     /**


### PR DESCRIPTION
for ex.

```
$mime = $fs->getMimetype($path);
$time = $fs->getTimestamp($path);
```

When there isn't cache, API is called twice.
