### PR TITLE
Add getClient() method for additional API calls

### DIFF
--- a/src/CopyAdapter.php
+++ b/src/CopyAdapter.php
@@ -41,6 +41,16 @@ class CopyAdapter extends AbstractAdapter
         $this->client = $client;
         $this->setPathPrefix($prefix);
     }
+    
+    /**
+     * Get the Copy API instance.
+     *
+     * @return API
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
 
     /**
      * Check weather a file exists.

--- a/tests/CopyAdapterTests.php
+++ b/tests/CopyAdapterTests.php
@@ -274,4 +274,12 @@ class CopyAdapterTests extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('copy')->andThrow('Exception');
         $this->assertFalse($adapter->copy('something', 'something'));
     }
+    
+    /**
+     * @dataProvider  copyProvider
+     */
+    public function testGetClient($adapter, $mock)
+    {
+        $this->assertEquals($mock, $adapter->getClient());
+    }
 }


### PR DESCRIPTION
Exposes the client so that you can make calls to the underlying API of Copy for things such as getting public links and other non-standard file system tasks.
