### PR TITLE
remove target dirctory from results of `listContents()`

### DIFF
--- a/src/CopyAdapter.php
+++ b/src/CopyAdapter.php
@@ -248,11 +248,14 @@ class CopyAdapter extends AbstractAdapter
             return [];
         }
 
+        $location = rtrim($location, '/');
         foreach ($result as $object) {
-            $listing[] = $this->normalizeObject($object, $object->path);
+            if ($location !== $object->path) {
+                $listing[] = $this->normalizeObject($object, $object->path);
 
-            if ($recursive && $object->type == 'dir') {
-                $listing = array_merge($listing, $this->listContents($object->path, $recursive));
+                if ($recursive && $object->type == 'dir') {
+                    $listing = array_merge($listing, $this->listContents($object->path, $recursive));
+                }
             }
         }
 


### PR DESCRIPTION
result of copy API library method `listPath()` includes target directory
meta data.

I got php error "Notice: Undefined index: dirname in league/flysystem/src/Util.php on line 20" when getting root(prefix-path) directory data.

Thanks!
